### PR TITLE
Fix for bug when gedit started in completely different directory

### DIFF
--- a/gtagJump/GtagsNavigator.py
+++ b/gtagJump/GtagsNavigator.py
@@ -1,26 +1,35 @@
 # -*- coding:utf-8 -*-
 
-import subprocess
+import os
 import re
+import subprocess
 
 
 class GtagsNavigator:
     def _call_global(self, doc, identifier, param):
+        cwd = os.getcwd()
         try:
+            doc_path = os.path.dirname(doc.get_location().get_path())
+            os.chdir(doc_path)
             text = subprocess.check_output(
                 ["/usr/bin/global", "--encode-path", " ", param, identifier]
             ).decode('utf8')
-
+            os.chdir(cwd)
             for line in text.split('\n'):
                 matchObj = re.search(
                     "^" + identifier + " +([0-9]+) +([^ ]+) +(.*)",
                     line
                 )
-                if matchObj:
-                    lineno, path, code = matchObj.groups()
-                    yield path.replace('%20', ' '), int(lineno), code
+                if not matchObj:
+                    continue
+
+                lineno, path, code = matchObj.groups()
+                path = path.replace('%20', ' ')
+                yield path, int(lineno), code, doc.get_location().get_path()
         except OSError:
             pass
+        finally:
+            os.chdir(cwd)
 
     def getDefinitions(self, doc, identifier):
         yield from self._call_global(doc, identifier, '-x')

--- a/gtagJump/PythonNavigator.py
+++ b/gtagJump/PythonNavigator.py
@@ -7,14 +7,15 @@ class PythonNavigator:
     def getDefinitions(self, doc, identifier):
         if doc.get_language().get_name() != "Python":
             return
-        with open(doc.get_location().get_path()) as f:
+        doc_location = doc.get_location()
+        with open(doc_location.get_path()) as f:
             table = symtable.symtable(
                 f.read(),
-                doc.get_location().get_basename(),
+                doc_location.get_basename(),
                 "exec",
             )
             for line in self.generateDefLines(table, identifier):
-                yield doc.get_location(), line, ""
+                yield doc_location, line, "", doc_location.get_path()
 
     def generateDefLines(self, table, identifier):
         for c in table.get_children():

--- a/gtagJump/PythonNavigator.py
+++ b/gtagJump/PythonNavigator.py
@@ -14,14 +14,13 @@ class PythonNavigator:
                 "exec",
             )
             for line in self.generateDefLines(table, identifier):
-                yield (doc.get_location(), line, "")
+                yield doc.get_location(), line, ""
 
     def generateDefLines(self, table, identifier):
         for c in table.get_children():
             if c.get_name() == identifier:
                 yield c.get_lineno()
-            for l in self.generateDefLines(c, identifier):
-                yield l
+            yield from self.generateDefLines(c, identifier)
 
     def getReferences(self, doc, identifier):
         pass

--- a/gtagJump/__init__.py
+++ b/gtagJump/__init__.py
@@ -87,7 +87,7 @@ class GtagJumpWindowActivatable(GObject.Object, Gedit.WindowActivatable):
         refs = []
         for navi in settings.navigator:
             try:
-                refs += [d for d in navi_method(navi)(doc, identifier)]
+                refs += navi_method(navi)(doc, identifier)
             except TypeError:
                 continue
         self.add_history(self.backstack)
@@ -119,18 +119,17 @@ class GtagJumpWindowActivatable(GObject.Object, Gedit.WindowActivatable):
         """
         locations: [(Gio.File, int)] or [(str, int), ...]
         """
-        if len(locations) != 0:
-            if len(locations) == 1:
-                if isinstance(locations[0][0], Gio.File):
-                    location = locations[0][0]
-                else:
-                    location = Gio.File.new_for_path(locations[0][0])
-                line = locations[0][1]
-                self.open_location(location, line)
-            elif len(locations) > 1:
-                locations.sort()
-                window = selectWindow.SelectWindow(self, identifier, locations)
-                window.show_all()
+        if len(locations) == 1:
+            if isinstance(locations[0][0], Gio.File):
+                location = locations[0][0]
+            else:
+                location = Gio.File.new_for_path(locations[0][0])
+            line = locations[0][1]
+            self.open_location(location, line)
+        elif len(locations) > 1:
+            locations.sort()
+            window = selectWindow.SelectWindow(self, identifier, locations)
+            window.show_all()
 
     def add_history(self, stack):
         doc = self.window.get_active_document()

--- a/gtagJump/selectWindow.py
+++ b/gtagJump/selectWindow.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 
-import os
 import sys
-from gi.repository import Gtk, Gio, Gdk
+from gi.repository import Gtk, Gdk
 
 
 class TreeViewWithColumn(Gtk.TreeView):
@@ -16,7 +15,7 @@ class TreeViewWithColumn(Gtk.TreeView):
 
 
 class SelectWindow(Gtk.Window):
-    def __init__(self, plugin, windowTitle, recodes):
+    def __init__(self, plugin, windowTitle, records, opener):
         Gtk.Window.__init__(self)
         self.plugin = plugin
         self.treeview = TreeViewWithColumn(
@@ -27,10 +26,11 @@ class SelectWindow(Gtk.Window):
         self.connect("button-press-event", self.__enter)
         sw = Gtk.ScrolledWindow()
         sw.add(self.treeview)
-        for rec in recodes:
+        for rec in records:
             if rec is not None:
                 self.treeview.get_model().append(rec)
         self.add(sw)
+        self.opener = opener
         self.set_title(windowTitle)
         self.set_size_request(700, 360)
 
@@ -44,11 +44,9 @@ class SelectWindow(Gtk.Window):
             )
         ):
             model, tree_iter = self.treeview.get_selection().get_selected()
-            path, line, doc_path = model.get(tree_iter, 0, 1, 3)
+            location = model.get(tree_iter, 0, 1, 2, 3)
             self.destroy()
-            dirname = os.path.dirname(doc_path)
-            newpath = os.path.normpath(os.path.join(dirname, path))
-            self.plugin.open_location(Gio.File.new_for_path(newpath), line)
+            self.opener(location)
 
 
 class MockPlugin:


### PR DESCRIPTION
The plugin did not work if gedit started from icon or e.g. /home/user

while   GTAGS were in /home/user/src/some_project

Now it is fixed as search is done from the open document directory
